### PR TITLE
Update to AgeWizard

### DIFF
--- a/hoki/age_utils.py
+++ b/hoki/age_utils.py
@@ -8,6 +8,7 @@ import warnings
 from hoki.utils.exceptions import HokiFatalError, HokiUserWarning, HokiFormatError, HokiFormatWarning
 from hoki.utils.hoki_object import HokiObject
 
+
 class AgeWizard(HokiObject):
     """
     AgeWizard object
@@ -64,36 +65,37 @@ class AgeWizard(HokiObject):
         self.coordinates = find_coordinates(self.obs_df, self.model)
         self._distributions = calculate_distributions(self.obs_df, self.model)
         self.pdfs = calculate_pdfs(self.obs_df, self.model).fillna(0)
-        self.sources = self.pdfs.columns[:-1].to_list()
+        self.sources = self.pdfs.columns.to_list()
         self.multiplied_pdf = None
         self.aggregate_pdf = None
         self._most_likely_age = None
-        self._most_likely_ages = None
 
-    def multiply_pdfs(self, not_you=None, return_df=False, smart=True):
-        """
-        Calls the multiply_pdfs function
-
-        Parameters
-        ----------
-        not_you: list, optional
-            List of the column names to ignore. Default is None so all the pdfs are multiplied
-        return_df: bool, optional
-            Whether or not the resulting DataFrame should be returned (it is automatically stored in the
-            attribute multiplied_pdf). Default is False.
-
-        Returns
-        -------
-            None or pandas.DataFrame containing the multiplied pdf.
-
-        """
-
-        self.multiplied_pdf = multiply_pdfs(self.pdfs, not_you, smart=smart)
-
-        if return_df: return self.multiplied_pdf
+    # Deprecated already - Multiplyind probabilities of stars in a cluster is a
+    # terrible idea since they;re not independent
+    # def multiply_pdfs(self, not_you=None, return_df=False, smart=True):
+    #     """
+    #     Calls the multiply_pdfs function
+    #
+    #     Parameters
+    #     ----------
+    #     not_you: list, optional
+    #         List of the column names to ignore. Default is None so all the pdfs are multiplied
+    #     return_df: bool, optional
+    #         Whether or not the resulting DataFrame should be returned (it is automatically stored in the
+    #         attribute multiplied_pdf). Default is False.
+    #
+    #     Returns
+    #     -------
+    #         None or pandas.DataFrame containing the multiplied pdf.
+    #
+    #     """
+    #
+    #     self.multiplied_pdf = multiply_pdfs(self.pdfs, not_you, smart=smart)
+    #
+    #     if return_df: return self.multiplied_pdf
 
     def aggregate_pdfs(self, not_you=None, return_df=False):
-        self.aggregate_pdf = calculate_aggregate_pdf(self._distributions, not_you)
+        self.aggregate_pdf = calculate_aggregate_pdf(self._distributions, not_you=not_you)
         if return_df: return self.aggregate_pdf
 
     @property
@@ -102,11 +104,11 @@ class AgeWizard(HokiObject):
         Finds  the most likely age by finding the max value in self.multiplied_pdf
         """
         if self._most_likely_age is not None: return self._most_likely_age
-        if self.multiplied_pdf is None:
+        if self.aggregate_pdf is None:
             warnings.warn('self.multiplied_pdf is not yet defined -- running AgeWizard.combined_pdfs()', HokiUserWarning)
-            self.multiply_pdfs()
+            self.aggregate_pdfs()
 
-        index = self.multiplied_pdf.index[self.multiplied_pdf.pdf == max(self.multiplied_pdf.pdf)].tolist()
+        index = self.aggregate_pdf.index[self.aggregate_pdf.pdf == max(self.aggregate_pdf.pdf)].tolist()
         return self.t[index]
 
     @property
@@ -114,9 +116,6 @@ class AgeWizard(HokiObject):
         """
         Finds the most likely ages for all the sources given in the obs_df DataFrame.
         """
-        if self._most_likely_ages is not None:
-            return self._most_likely_ages
-
         #index = self.pdfs.drop('time_bins', axis=1).idxmax(axis=0).tolist()
         index = self.pdfs.idxmax(axis=0).tolist()
         return self.t[index]
@@ -358,18 +357,18 @@ def calculate_distributions(obs_df, model):
     # Our list of pdfs (which is a list of lists) is turned into a PDF with the source names as column names
     likelihoods_df = pd.DataFrame((np.array(likelihoods)).T, columns=source_names)
     # We add the time bins in there because it can make plotting extra convenient.
-    #pdf_df['time_bins'] = hoki.constants.BPASS_TIME_BINS
+    #distribution_df['time_bins'] = hoki.constants.BPASS_TIME_BINS
 
     return likelihoods_df
 
 
-def multiply_pdfs(pdf_df, not_you=None, smart=True):
+def calculate_aggregate_pdf(distribution_df, not_you=None):
     """
     Multiplies together all the columns in given in DataFrame apart from the "time_bins" column
 
     Parameters
     ----------
-    pdf_df: pandas.DataFrame
+    distribution_df: pandas.DataFrame
         DataFrame containing probability distribution functions
     not_you: list, optional
         List of the column names to ignore. Default is None so all the pdfs are multiplied
@@ -378,16 +377,16 @@ def multiply_pdfs(pdf_df, not_you=None, smart=True):
     -------
     Combined Probability Distribution Function in a pandas.DataFrame.
     """
-    assert isinstance(pdf_df, pd.DataFrame)
+    assert isinstance(distribution_df, pd.DataFrame)
 
     # We start our combined pdf with a list of 1s. We'll the multiply each pdf in sequence.
 
-    combined_pdf = [1] * pdf_df.shape[0]
+    combined_pdf = [0] * distribution_df.shape[0]
 
     # We want to allow the user to exclude certain columns -- we drop them here.
     if not_you:
         try:
-            pdf_df = pdf_df.drop(labels=not_you, axis=1)
+            distribution_df = distribution_df.drop(labels=not_you, axis=1)
         except KeyError as e:
             message = 'FEATURE DISABLED'+'\nKeyError'+str(e)+'\nHOKI DIALOGUE: Your labels could not be dropped -- ' \
                                                               'all pdfs will be combined \nDEBUGGING ASSISTANT: ' \
@@ -396,61 +395,65 @@ def multiply_pdfs(pdf_df, not_you=None, smart=True):
 
     # We also must be careful not to multiply the time bin column in there so we have a list of the column names
     # that remain after the "not_you" exclusion minus the time_bins column.
-    columns = [col for col in pdf_df.columns if "time_bins" not in col]
+    columns = [col for col in distribution_df.columns if "time_bins" not in col]
+
+    for col in columns:
+    #for col in distribution_df.columns:
+        combined_pdf += distribution_df[col].values
+
+    combined_df = pd.DataFrame(normalise_1d(combined_pdf))
+    combined_df.columns = ['pdf']
+
+    return combined_df
+
+
+"""
+def multiply_pdfs(distribution_df, not_you=None, smart=True):
+
+    Multiplies together all the columns in given in DataFrame apart from the "time_bins" column
+
+    Parameters
+    ----------
+    distribution_df: pandas.DataFrame
+        DataFrame containing probability distribution functions
+    not_you: list, optional
+        List of the column names to ignore. Default is None so all the pdfs are multiplied
+
+    Returns
+    -------
+    Combined Probability Distribution Function in a pandas.DataFrame.
+
+    assert isinstance(distribution_df, pd.DataFrame)
+
+    # We start our combined pdf with a list of 1s. We'll the multiply each pdf in sequence.
+
+    combined_pdf = [1] * distribution_df.shape[0]
+
+    # We want to allow the user to exclude certain columns -- we drop them here.
+    if not_you:
+        try:
+            distribution_df = distribution_df.drop(labels=not_you, axis=1)
+        except KeyError as e:
+            message = 'FEATURE DISABLED'+'\nKeyError'+str(e)+'\nHOKI DIALOGUE: Your labels could not be dropped -- ' \
+                                                              'all pdfs will be combined \nDEBUGGING ASSISTANT: ' \
+                                                              'Make sure the labels your listed are spelled correctly:)'
+            warnings.warn(message, HokiUserWarning)
+
+    # We also must be careful not to multiply the time bin column in there so we have a list of the column names
+    # that remain after the "not_you" exclusion minus the time_bins column.
+    columns = [col for col in distribution_df.columns if "time_bins" not in col]
 
     if smart:
-        columns = [col for col in columns if round(sum(pdf_df[col]), 2) != 0.0]
+        columns = [col for col in columns if round(sum(distribution_df[col]), 2) != 0.0]
         # smart mode automatically doesn't take into account the columnd that add up to a proba of 0
         # this happens when matching coordinates can't be found for an observation.
 
-    for col in columns:  # pdf_df.columns[:-1]:
-        combined_pdf *= pdf_df[col].values
+    for col in columns:  # distribution_df.columns[:-1]:
+        combined_pdf *= distribution_df[col].values
 
     combined_df = pd.DataFrame(normalise_1d(combined_pdf))
     combined_df.columns = ['pdf']
 
     return combined_df
 
-def calculate_aggregate_pdf(pdf_df, not_you=None, smart=True):
-    """
-    Multiplies together all the columns in given in DataFrame apart from the "time_bins" column
-
-    Parameters
-    ----------
-    pdf_df: pandas.DataFrame
-        DataFrame containing probability distribution functions
-    not_you: list, optional
-        List of the column names to ignore. Default is None so all the pdfs are multiplied
-
-    Returns
-    -------
-    Combined Probability Distribution Function in a pandas.DataFrame.
-    """
-    assert isinstance(pdf_df, pd.DataFrame)
-
-    # We start our combined pdf with a list of 1s. We'll the multiply each pdf in sequence.
-
-    combined_pdf = [0] * pdf_df.shape[0]
-
-    # We want to allow the user to exclude certain columns -- we drop them here.
-    if not_you:
-        try:
-            pdf_df = pdf_df.drop(labels=not_you, axis=1)
-        except KeyError as e:
-            message = 'FEATURE DISABLED'+'\nKeyError'+str(e)+'\nHOKI DIALOGUE: Your labels could not be dropped -- ' \
-                                                              'all pdfs will be combined \nDEBUGGING ASSISTANT: ' \
-                                                              'Make sure the labels your listed are spelled correctly:)'
-            warnings.warn(message, HokiUserWarning)
-
-    # We also must be careful not to multiply the time bin column in there so we have a list of the column names
-    # that remain after the "not_you" exclusion minus the time_bins column.
-    columns = [col for col in pdf_df.columns if "time_bins" not in col]
-
-
-    for col in columns:  # pdf_df.columns[:-1]:
-        combined_pdf += pdf_df[col].values
-
-    combined_df = pd.DataFrame(normalise_1d(combined_pdf))
-    combined_df.columns = ['pdf']
-
-    return combined_df
+"""

--- a/hoki/cmd.py
+++ b/hoki/cmd.py
@@ -8,9 +8,9 @@ from hoki.constants import *
 import numpy as np
 import matplotlib.cm as cm
 from hoki.utils.exceptions import HokiFatalError, HokiUserWarning, HokiFormatError, HokiKeyError
+from hoki.utils.hoki_object import HokiObject
 
-
-class CMD(object):
+class CMD(HokiObject):
     """
     **Colour Magnitude Diagram Object**
 

--- a/hoki/hrdiagrams.py
+++ b/hoki/hrdiagrams.py
@@ -9,9 +9,10 @@ from matplotlib import ticker
 import matplotlib.cm as cm
 from hoki.utils.exceptions import HokiFatalError, HokiUserWarning, HokiFormatError
 import warnings
+from hoki.utils.hoki_object import HokiObject
 
 
-class HRDiagram(object):
+class HRDiagram(HokiObject):
     """
     **A class containing the HR diagram data produced by BPASS.**
 
@@ -95,10 +96,6 @@ class HRDiagram(object):
 
 
     """
-    # Just some BPASS things
-    t = BPASS_TIME_BINS
-    dt = BPASS_TIME_INTERVALS
-    _time_weights = BPASS_TIME_WEIGHT_GRID
 
     # HRD coordinates
     T_coord = np.arange(0.1, 10.1, 0.1)
@@ -348,9 +345,9 @@ class HRDiagram(object):
     def _apply_time_weighting(self):
         """ Weighs all 51 grids by the number of years in each bin."""
 
-        self.high_H = self.high_H_not_weighted*self._time_weights
-        self.medium_H = self.medium_H_not_weighted*self._time_weights
-        self.low_H = self.low_H_not_weighted*self._time_weights
+        self.high_H = self.high_H_not_weighted*self.time_weight_grid
+        self.medium_H = self.medium_H_not_weighted*self.time_weight_grid
+        self.low_H = self.low_H_not_weighted*self.time_weight_grid
 
     # Now we can index HR diagrams!
     def __getitem__(self, item):

--- a/hoki/tests/test_aging.py
+++ b/hoki/tests/test_aging.py
@@ -55,8 +55,8 @@ class TestAgeWizard(object):
 
     def test_combine_pdfs_not_you(self):
         wiz = au.AgeWizard(fake_hrd_input, myhrd)
-        wiz.aggregate_pdfs(not_you=['star1'])
-        cpdf = wiz.aggregate_pdf.pdf
+        wiz.calculate_sample_pdf(not_you=['star1'])
+        cpdf = wiz.sample_pdf.pdf
         assert np.sum(np.isclose([cpdf[0], cpdf[9]], [0.0, 0.774602971512809])) == 2, "combined pdf is not right"
 
     def test_most_likely_age(self):
@@ -70,8 +70,8 @@ class TestAgeWizard(object):
 
     def test_combine_pdfs(self):
         wiz = au.AgeWizard(fake_hrd_input, myhrd)
-        wiz.aggregate_pdfs()
-        assert np.isclose(wiz.aggregate_pdf.pdf[9], 0.2715379752638662), "Something is wrong with the combined_Age PDF"
+        wiz.calculate_sample_pdf()
+        assert np.isclose(wiz.sample_pdf.pdf[9], 0.2715379752638662), "Something is wrong with the combined_Age PDF"
 
     def test_calculate_p_given_age_range(self):
         wiz = au.AgeWizard(fake_hrd_input, myhrd)
@@ -145,34 +145,34 @@ class TestNormalise1D(object):
 
 class TestCalculatePDFs(object):
     def test_fake_input(self):
-        pdf_df = au.calculate_pdfs(fake_hrd_input, myhrd)
+        pdf_df = au.calculate_individual_pdfs(fake_hrd_input, myhrd)
         assert 'star1' in pdf_df.columns, "Column name issue"
         assert int(sum(pdf_df.star1)) == 1, "PDF not calculated correctly"
 
     def test_input_without_name(self):
-        pdf_df = au.calculate_pdfs(no_name_input, myhrd)
+        pdf_df = au.calculate_individual_pdfs(no_name_input, myhrd)
         assert 's1' in pdf_df.columns, "Column names not created right"
 
     def test_bad_input(self):
-        pdf_df = au.calculate_pdfs(bad_hrd_input2, myhrd)
+        pdf_df = au.calculate_individual_pdfs(bad_hrd_input2, myhrd)
         assert not np.isnan(sum(pdf_df.s0)), "somwthing went wrong"
-        #assert np.isnan(sum(distribution_df.s1)), "somwthing went wrong"
+        #assert np.isnan(sum(distributions_df.s1)), "somwthing went wrong"
 
 
-class TestAggregatePDFs(object):
+class TestCalculateSamplePDF(object):
     def test_basic(self):
         distributions = au.calculate_distributions(fake_hrd_input, myhrd)
-        combined = au.calculate_aggregate_pdf(distributions)
+        combined = au.calculate_sample_pdf(distributions)
         assert np.isclose(combined.pdf[9], 0.2715379752638662), "combined PDF not right"
 
     def test_drop_bad(self):
         distributions = au.calculate_distributions(fake_hrd_input, myhrd)
-        combined = au.calculate_aggregate_pdf(distributions, not_you=[3])
+        combined = au.calculate_sample_pdf(distributions, not_you=[3])
         assert np.isclose(combined.pdf[9], 0.2715379752638662), "combined PDF not right"
 
     def test_drop_good(self):
         distributions = au.calculate_distributions(fake_hrd_input, myhrd)
-        combined = au.calculate_aggregate_pdf(distributions, not_you=['star1'])
+        combined = au.calculate_sample_pdf(distributions, not_you=['star1'])
         assert np.isclose(combined.pdf[9], 0.774602971512809), "combined PDF not right"
 
 

--- a/hoki/tests/test_aging.py
+++ b/hoki/tests/test_aging.py
@@ -55,9 +55,9 @@ class TestAgeWizard(object):
 
     def test_combine_pdfs_not_you(self):
         wiz = au.AgeWizard(fake_hrd_input, myhrd)
-        wiz.multiply_pdfs(not_you=['star1'])
-        cpdf = wiz.multiplied_pdf.pdf
-        assert np.sum(np.isclose([cpdf[0], cpdf[9]], [0.0, 0.878162355350702])) == 2, "combined pdf is not right"
+        wiz.aggregate_pdfs(not_you=['star1'])
+        cpdf = wiz.aggregate_pdf.pdf
+        assert np.sum(np.isclose([cpdf[0], cpdf[9]], [0.0, 0.774602971512809])) == 2, "combined pdf is not right"
 
     def test_most_likely_age(self):
         wiz = au.AgeWizard(obs_df=fake_hrd_input, model=hr_file)
@@ -70,8 +70,8 @@ class TestAgeWizard(object):
 
     def test_combine_pdfs(self):
         wiz = au.AgeWizard(fake_hrd_input, myhrd)
-        wiz.multiply_pdfs()
-        assert np.isclose(wiz.multiplied_pdf.pdf[9], 0.9837195045903536), "Something is wrong with the combined_Age PDF"
+        wiz.aggregate_pdfs()
+        assert np.isclose(wiz.aggregate_pdf.pdf[9], 0.2715379752638662), "Something is wrong with the combined_Age PDF"
 
     def test_calculate_p_given_age_range(self):
         wiz = au.AgeWizard(fake_hrd_input, myhrd)
@@ -156,9 +156,27 @@ class TestCalculatePDFs(object):
     def test_bad_input(self):
         pdf_df = au.calculate_pdfs(bad_hrd_input2, myhrd)
         assert not np.isnan(sum(pdf_df.s0)), "somwthing went wrong"
-        #assert np.isnan(sum(pdf_df.s1)), "somwthing went wrong"
+        #assert np.isnan(sum(distribution_df.s1)), "somwthing went wrong"
 
 
+class TestAggregatePDFs(object):
+    def test_basic(self):
+        distributions = au.calculate_distributions(fake_hrd_input, myhrd)
+        combined = au.calculate_aggregate_pdf(distributions)
+        assert np.isclose(combined.pdf[9], 0.2715379752638662), "combined PDF not right"
+
+    def test_drop_bad(self):
+        distributions = au.calculate_distributions(fake_hrd_input, myhrd)
+        combined = au.calculate_aggregate_pdf(distributions, not_you=[3])
+        assert np.isclose(combined.pdf[9], 0.2715379752638662), "combined PDF not right"
+
+    def test_drop_good(self):
+        distributions = au.calculate_distributions(fake_hrd_input, myhrd)
+        combined = au.calculate_aggregate_pdf(distributions, not_you=['star1'])
+        assert np.isclose(combined.pdf[9], 0.774602971512809), "combined PDF not right"
+
+
+"""
 class TestMultiplyPDFs(object):
     def test_basic(self):
         pdfs_good = au.calculate_pdfs(fake_hrd_input, myhrd)
@@ -174,3 +192,4 @@ class TestMultiplyPDFs(object):
         pdfs_good = au.calculate_pdfs(fake_hrd_input, myhrd)
         combined = au.multiply_pdfs(pdfs_good, not_you=['star1'])
         assert np.isclose(combined.pdf[9], 0.878162355350702), "combined PDF not right"
+"""

--- a/hoki/utils/hoki_object.py
+++ b/hoki/utils/hoki_object.py
@@ -5,5 +5,6 @@ class HokiObject(object):
     t = BPASS_TIME_BINS
     dt = BPASS_TIME_INTERVALS
     time_weight_grid = BPASS_TIME_WEIGHT_GRID
+
     def __init__(self):
         pass

--- a/hoki/utils/hoki_object.py
+++ b/hoki/utils/hoki_object.py
@@ -1,0 +1,9 @@
+from hoki.constants import BPASS_TIME_BINS, BPASS_TIME_INTERVALS, BPASS_TIME_WEIGHT_GRID
+
+
+class HokiObject(object):
+    t = BPASS_TIME_BINS
+    dt = BPASS_TIME_INTERVALS
+    time_weight_grid = BPASS_TIME_WEIGHT_GRID
+    def __init__(self):
+        pass


### PR DESCRIPTION
Refactors
-----

- `calculate_pdfs` is now `calculate_individual_pdfs` and the functionality has been split with `calculate_distributions` (see below)
- `multiple_pdfs` fully deprecated. 

It has come to my attention that multiplying the probability density functions of the ages of the sources in a cluster was incorrect since these ages are correlated. 

New Functions
----
- `calculate_distributions`: Searches through CMD/HRDs to collate the age distributions for a set of locations on the CMD/HRDs

