### PR TITLE
Custom filter bug fix

### DIFF
--- a/hoki/spec.py
+++ b/hoki/spec.py
@@ -181,7 +181,11 @@ def import_custom_filter(filename):
         The bandpass filter from the file.
     """
     votable = astropy.io.votable.parse(filename).get_first_table()
-    return psp.ArrayBandpass(votable.array["Wavelength"].filled(),
-                             votable.array["Transmission"].filled(),
+    wl = votable.array["Wavelength"].filled()
+    tr = votable.array["Transmission"].filled()
+    wl_edges = np.append(np.append(wl[0]-1, wl),wl[-1]+1)
+    tr_edges = np.append(np.append(0.0, tr), 0.0)
+    return psp.ArrayBandpass(wl_edges,
+                             tr_edges,
                              name=votable.params[1].value.decode('utf-8')
                              )

--- a/hoki/tests/test_spec.py
+++ b/hoki/tests/test_spec.py
@@ -9,8 +9,8 @@ import pytest
 data_path = pkg_resources.resource_filename('hoki', 'data')
 
 #wavelengths and throughput/transmission manually read from the LICK.LICK.U file
-wl = [3100,3200,3300,3400,3500,3600,3700,3800,3900,4000,4100]
-transmission = [0.015, 0.140,0.347,0.440,0.625,0.685,0.708,0.643,0.458,0.170,0.029]
+wl = [3099,3100,3200,3300,3400,3500,3600,3700,3800,3900,4000,4100,4101]
+transmission = [0.0,0.015, 0.140,0.347,0.440,0.625,0.685,0.708,0.643,0.458,0.170,0.029,0.0]
 data = load.model_output(f"{data_path}/spectra-bin-imf135_300.z002.dat")
 
 def test_dopcor():


### PR DESCRIPTION
Values outside the filter range for custom filters are now set to be 0, instead of the last value of the filter. 