### PR TITLE
Updating AgeWizard Algorithm

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,8 +27,8 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
+        python3 -m pip install --upgrade pip
+        python3 -m pip install tox
         
     - name: Run Tox
       run: tox

--- a/hoki/cmd.py
+++ b/hoki/cmd.py
@@ -92,7 +92,8 @@ class CMD(HokiObject):
         self._log_ages = None
         self._ages = None
         self.mag_filter = None
-        self.filter2 = None
+        self.col_filter1 = None
+        self.col_filter2 = None
 
     def make(self, mag_filter, col_filters):
         """

--- a/hoki/constants.py
+++ b/hoki/constants.py
@@ -25,6 +25,8 @@ BPASS_TIME_BINS = np.arange(6.0, 11.1, 0.1)
 BPASS_TIME_INTERVALS = np.array([10**(t+0.05) - 10**(t-0.05) for t in BPASS_TIME_BINS])
 BPASS_TIME_WEIGHT_GRID = np.array([np.zeros((100,100)) + dt for dt in BPASS_TIME_INTERVALS])
 
+HOKI_NOW = 13.799e9
+
 # Create a deprecation warning when using dummy_dict
 dummy_dict = {'timestep': 0, 'age': 1, 'log(R1)': 2, 'log(T1)': 3, 'log(L1)': 4, 'M1': 5, 'He_core1': 6, 'CO_core1': 7,
               'ONe_core1': 8, 'X': 10, 'Y': 11, 'C': 12, 'N': 13, 'O': 14, 'Ne': 15, 'MH1': 16, 'MHe1': 17, 'MC1': 18,

--- a/hoki/stats/starcounts.py
+++ b/hoki/stats/starcounts.py
@@ -4,6 +4,8 @@ import emcee
 import pandas as pd
 import corner
 import matplotlib.pyplot as plt
+from hoki.utils.exceptions import HokiTypeError
+
 
 def ratio_with_poisson_errs(n1, n2):
     """
@@ -24,9 +26,14 @@ def ratio_with_poisson_errs(n1, n2):
     R and dR (floats) - Star Count Ratio and its error
 
     """
-    R = n1/n2
-    dR = R*np.sqrt((1/n1)+(1/n2))
+    try:
+        R = n1/n2
+        dR = R*np.sqrt((1/n1)+(1/n2))
+    except TypeError as e:
+        raise HokiTypeError(f"Make sure you provide ints or floats.")
+
     return R, dR
+
 
 class UnderlyingCountRatio(HokiObject):
     """

--- a/hoki/stats/starcounts.py
+++ b/hoki/stats/starcounts.py
@@ -5,7 +5,6 @@ import pandas as pd
 import corner
 import matplotlib.pyplot as plt
 
-#TODO: UNITEST
 def ratio_with_poisson_errs(n1, n2):
     """
     Returns Star Count Ratio and its error
@@ -29,7 +28,6 @@ def ratio_with_poisson_errs(n1, n2):
     dR = R*np.sqrt((1/n1)+(1/n2))
     return R, dR
 
-#TODO: UNITEST
 class UnderlyingCountRatio(HokiObject):
     """
     Pipeline to calculate the underlying stellar number count ratio from observed stellar numbers
@@ -197,9 +195,12 @@ class UnderlyingCountRatio(HokiObject):
             return self.summary_df
 
         columns = ['Variable', f'{int(50 - self.ci_width / 2)}th', '50th', f'{int(50 + self.ci_width / 2)}th']
-        self.summary_df = pd.DataFrame(np.array([np.concatenate((np.array(['R_hat']), np.round(self.R_hat, 4))),
-                                                 np.concatenate((np.array(['n2_hat']), np.round(self.n2_hat, 4)))]),
-                                       columns=columns)
+        row1 = np.array(['R_hat', np.round(self.R_hat[2], 4),
+                         np.round(self.R_hat[0], 4), np.round(self.R_hat[1], 4)])
+        row2 = np.array(['n2_hat', np.round(self.n2_hat[2], 4),
+                         np.round(self.n2_hat[1], 4), np.round(self.n2_hat[0], 4)])
+
+        self.summary_df = pd.DataFrame(np.array([row1, row2]), columns=columns)
         return self.summary_df
 
     def corner_plot(self, output_file='corner_plot.png', show=True):

--- a/hoki/stats/tests/test_starcounts.py
+++ b/hoki/stats/tests/test_starcounts.py
@@ -1,12 +1,20 @@
 from hoki.stats.starcounts import UnderlyingCountRatio, ratio_with_poisson_errs
 import pandas as pd
 import numpy as np
+from hoki.utils.exceptions import HokiTypeError
+import pytest
 
 
 def test_ratio_with_poisson_errors():
     R, dR = ratio_with_poisson_errs(2,4)
     assert np.isclose(R, 0.50, atol=0.005), "Ratio is wrong"
     assert np.isclose(dR, 0.43, atol=0.005), "Errors are wrong"
+
+
+def test_ratio_with_poisson_errors_fail():
+    with pytest.raises(HokiTypeError):
+        __, __ = ratio_with_poisson_errs('bla', 4), 'HokiTypeError should be raised'
+
 
 class TestUnderlyingCountRatio(object):
     def test_init(self):

--- a/hoki/tests/test_aging.py
+++ b/hoki/tests/test_aging.py
@@ -57,7 +57,7 @@ class TestAgeWizard(object):
         wiz = au.AgeWizard(fake_hrd_input, myhrd)
         wiz.calculate_sample_pdf(not_you=['star1'])
         cpdf = wiz.sample_pdf.pdf
-        assert np.sum(np.isclose([cpdf[0], cpdf[9]], [0.0, 0.774602971512809])) == 2, "combined pdf is not right"
+        assert np.sum(np.isclose([cpdf[0], cpdf[9]], [0.0, 0.7231526323765232])) == 2, "combined pdf is not right"
 
     def test_most_likely_age(self):
         wiz = au.AgeWizard(obs_df=fake_hrd_input, model=hr_file)
@@ -71,7 +71,7 @@ class TestAgeWizard(object):
     def test_combine_pdfs(self):
         wiz = au.AgeWizard(fake_hrd_input, myhrd)
         wiz.calculate_sample_pdf()
-        assert np.isclose(wiz.sample_pdf.pdf[9], 0.2715379752638662), "Something is wrong with the combined_Age PDF"
+        assert np.isclose(wiz.sample_pdf.pdf[9], 0.5517567341458788), "Something is wrong with the combined_Age PDF"
 
     def test_calculate_p_given_age_range(self):
         wiz = au.AgeWizard(fake_hrd_input, myhrd)
@@ -135,10 +135,10 @@ class TestFindHRDCoordinates(object):
 
 class TestNormalise1D(object):
     def test_it_runs(self):
-        au.normalise_1d(np.array([0, 1, 4, 5, 0, 1, 7, 8]))
+        au.normalise_1d(np.array([0, 1, 4, 5, 0, 1, 7, 8]), crop_the_future=False)
 
     def test_basic(self):
-        norm = au.normalise_1d(np.array([0, 0, 1, 0, 0, 0, 0]))
+        norm = au.normalise_1d(np.array([0, 0, 1, 0, 0, 0, 0]), crop_the_future=False)
         assert norm[2] == 1, 'Normalisation done wrong'
         assert sum(norm) == 1, "Normalisaton done wrong"
 

--- a/hoki/utils/exceptions.py
+++ b/hoki/utils/exceptions.py
@@ -48,3 +48,9 @@ class HokiKeyError(KeyError):
     """
     Hoki Key error
     """
+
+class HokiTypeError(KeyError):
+    """
+    Hoki Type error
+    """
+

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@
 [tox]
 envlist =
      py36-test-numpy{116,117,118}
-     py37-test-numpy{116,117,118}
+     python3.7-test-numpy{116,117,118}
      py36-test-pandas{025,1}
- 	 py37-test-pandas{025,1}
+ 	 python3.7-test-pandas{025,1}
 
 [testenv]
 setenv = PYSYN_CDBS = {toxinidir}/hoki/data/cdbs/
@@ -19,7 +19,6 @@ deps =
     pandas025: pandas==0.25.*
     pandas1: pandas==1.0.*
     pytest
-    codecov
 commands =
     pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,11 @@
 
 [tox]
 envlist =
-     py{36,37}-test-numpy{116,117,118}
-     py{36,37}-test-pandas{025,1}
-     #py37-cov
-#     cov_report
+     py36-test-numpy{116,117,118}
+     py37-test-numpy{116,117,118}
+     py36-test-pandas{025,1}
+ 	 py37-test-pandas{025,1}
+
 [testenv]
 setenv = PYSYN_CDBS = {toxinidir}/hoki/data/cdbs/
 deps =


### PR DESCRIPTION
After the comments from the referee the algorithm for AgeWizard has been refined somewhat:

- The individual star age probability distribution functions are now such that the probability that a star has an age older than the current age of the Universe is 0
- The total probability density function is now calculated from the individual star PDFs, not from their unnormalised distributions. The original algorithm effectively leads to a higher weighting of stars found in densely populated regions of the HRD and CMDs. As a result, stars in the giant branch carried a significantly lower weight than main sequence stars. This is problematic because these stars carry the most reliable information about age since their evolutionary phase is much shorter lived than the Main Sequence. Consequently, normalising the distributions over time before combining them is a first step towards making the age determination more accurate. Further steps can be taken by the human and these will be described in soon-to-come tutorials and publications. Feel free to contact hfstevance@gmail.com if you need more detail about this. 

