### PR TITLE
Small bugfix in `all_spectra`

### DIFF
--- a/hoki/load.py
+++ b/hoki/load.py
@@ -552,7 +552,9 @@ def all_spectra(data_path, imf, binary=True):
     except FileNotFoundError:
         print("Failed")
         print("Data will be compiled")
-        spec = hoki.data_compilers.SpectraCompiler(data_path, data_path, imf)
+        spec = hoki.data_compilers.SpectraCompiler(
+            data_path, data_path, imf, binary=binary
+        )
         spectra = spec.spectra
     return spectra
 


### PR DESCRIPTION
The `binary` kwarg was not passed on to `SpectraCompiler` from `load.all_spectra`.