### PR TITLE
BUG: fix colnames in SpectraCompiler.

### DIFF
--- a/hoki/data_compilers.py
+++ b/hoki/data_compilers.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from hoki.constants import (BPASS_IMFS, BPASS_METALLICITIES,
-                            BPASS_NUM_METALLICITIES)
+                            BPASS_NUM_METALLICITIES, BPASS_TIME_BINS)
 from hoki.utils.progressbar import print_progress_bar
 
 
@@ -72,20 +72,18 @@ class SpectraCompiler():
             raise HokiKeyError(
                 f"{imf} is not a BPASS IMF. Please select a correct IMF.")
 
-
         # Setup the numpy output
-        spectra = np.zeros((13, 51, 100000), dtype=np.float64)
+        spectra = np.empty((13, 51, 100000), dtype=np.float64)
 
         # loop over all the metallicities and load all the specta
         for num, metallicity in enumerate(BPASS_METALLICITIES):
             print_progress_bar(num, 12)
 
             # use manual load, because otherwise a cyclic import is required.
+            names = ['wave']+["{:.1f}".format(x) for x in BPASS_TIME_BINS]
             data = pd.read_csv(f"{spectra_folder}/spectra-{star}-{imf}.z{metallicity}.dat",
                                sep=r"\s+",
-                               names=['log_age', 'Ia', 'IIP', 'II', 'Ib', 'Ic', 'LGRB', 'PISNe', 'low_mass',
-                               'e_Ia', 'e_IIP', 'e_II', 'e_Ib', 'e_Ic', 'e_LGRB', 'e_PISNe', 'e_low_mass',
-                               'age_yrs'],
+                               names=names,
                                engine='python')
             spectra[num] = data.loc[:, slice("6.0", "11.0")].T.to_numpy()
 


### PR DESCRIPTION
Fixes column `pandas` column names used in `SpectraCompiler.

I think this fixes a bug, loading did not work for me otherwise.