### PR TITLE
BUG: use np instead of pd in SpectraCompiler.

### DIFF
--- a/hoki/csp/tests/test_spectra.py
+++ b/hoki/csp/tests/test_spectra.py
@@ -29,13 +29,13 @@ class TestCSPSSpectra(object):
 
     # Load data to remove I/O for testing.
     data = model_output(
-        f"{data_path}/spectra-bin-imf135_300.z002.dat").loc[:, slice("6.0", "11.0")]
+        f"{data_path}/spectra-bin-imf135_300.z002.dat").to_numpy()
 
-    with patch("hoki.data_compilers.pd.read_csv") as mock_model_output:
+    with patch("hoki.data_compilers.np.loadtxt") as mock_model_output:
         mock_model_output.return_value = data
         CSP = CSPSpectra(f"{data_path}",  "imf135_300")
 
-    @patch("hoki.data_compilers.pd.read_csv")
+    @patch("hoki.data_compilers.np.loadtxt")
     def test_init(self, mock_model_output):
         mock_model_output.return_value = self.data
         CSP = CSPSpectra(f"{data_path}",  "imf135_300")

--- a/hoki/data_compilers.py
+++ b/hoki/data_compilers.py
@@ -5,10 +5,8 @@ Objects and pipelines that compile BPASS data files into more convenient, more p
 """
 
 import numpy as np
-import pandas as pd
 
-from hoki.constants import (BPASS_IMFS, BPASS_METALLICITIES,
-                            BPASS_NUM_METALLICITIES)
+from hoki.constants import BPASS_IMFS, BPASS_METALLICITIES
 from hoki.utils.progressbar import print_progress_bar
 
 
@@ -72,22 +70,13 @@ class SpectraCompiler():
             raise HokiKeyError(
                 f"{imf} is not a BPASS IMF. Please select a correct IMF.")
 
-
         # Setup the numpy output
-        spectra = np.zeros((13, 51, 100000), dtype=np.float64)
+        spectra = np.empty((13, 51, 100000), dtype=np.float64)
 
-        # loop over all the metallicities and load all the specta
+        # loop over all the metallicities and load all the spectra
         for num, metallicity in enumerate(BPASS_METALLICITIES):
             print_progress_bar(num, 12)
-
-            # use manual load, because otherwise a cyclic import is required.
-            data = pd.read_csv(f"{spectra_folder}/spectra-{star}-{imf}.z{metallicity}.dat",
-                               sep=r"\s+",
-                               names=['log_age', 'Ia', 'IIP', 'II', 'Ib', 'Ic', 'LGRB', 'PISNe', 'low_mass',
-                               'e_Ia', 'e_IIP', 'e_II', 'e_Ib', 'e_Ic', 'e_LGRB', 'e_PISNe', 'e_low_mass',
-                               'age_yrs'],
-                               engine='python')
-            spectra[num] = data.loc[:, slice("6.0", "11.0")].T.to_numpy()
+            spectra[num] = np.loadtxt(f"{spectra_folder}/spectra-{star}-{imf}.z{metallicity}.dat").T[:1, :]
 
         # pickle the datafile
         np.save(f"{output_folder}/all_spectra-{star}-{imf}", spectra)

--- a/hoki/data_compilers.py
+++ b/hoki/data_compilers.py
@@ -76,7 +76,7 @@ class SpectraCompiler():
         # loop over all the metallicities and load all the spectra
         for num, metallicity in enumerate(BPASS_METALLICITIES):
             print_progress_bar(num, 12)
-            spectra[num] = np.loadtxt(f"{spectra_folder}/spectra-{star}-{imf}.z{metallicity}.dat").T[:1, :]
+            spectra[num] = np.loadtxt(f"{spectra_folder}/spectra-{star}-{imf}.z{metallicity}.dat").T[1:, :]
 
         # pickle the datafile
         np.save(f"{output_folder}/all_spectra-{star}-{imf}", spectra)

--- a/hoki/tests/test_data_compilers.py
+++ b/hoki/tests/test_data_compilers.py
@@ -25,11 +25,10 @@ class TestSpectraCompiler(object):
 
     # Patch the model_output function
     @patch("hoki.data_compilers.np.loadtxt")
-    def test_compiler(self, mock_nploadtxt):
+    def test_compiler(self, mock_model_output):
 
-        print(self.data.shape)
         # Set the model_output to the DataFrame
-        mock_nploadtxt.return_value = self.data.to_numpy()
+        mock_model_output.return_value = self.data.to_numpy()
 
         spec = SpectraCompiler(f"{data_path}",
                                f"{data_path}",

--- a/hoki/tests/test_data_compilers.py
+++ b/hoki/tests/test_data_compilers.py
@@ -7,9 +7,7 @@ Tests for the data_compiler package
 import os.path
 from unittest.mock import patch
 
-import numpy as np
 import numpy.testing as npt
-import pandas as pd
 import pkg_resources
 
 from hoki.data_compilers import SpectraCompiler
@@ -23,14 +21,15 @@ class TestSpectraCompiler(object):
     # Initialise model_output DataFrame return a smaller single dataframe
     # This reduces I/O readings
     data = model_output(
-        f"{data_path}/spectra-bin-imf135_300.z002.dat").loc[:, slice("6.0", "11.0")]
+        f"{data_path}/spectra-bin-imf135_300.z002.dat")
 
     # Patch the model_output function
-    @patch("hoki.data_compilers.pd.read_csv")
-    def test_compiler(self, mock_model_output):
+    @patch("hoki.data_compilers.np.loadtxt")
+    def test_compiler(self, mock_nploadtxt):
 
+        print(self.data.shape)
         # Set the model_output to the DataFrame
-        mock_model_output.return_value = self.data
+        mock_nploadtxt.return_value = self.data.to_numpy()
 
         spec = SpectraCompiler(f"{data_path}",
                                f"{data_path}",
@@ -41,7 +40,10 @@ class TestSpectraCompiler(object):
 
         # Check output dataframe
         npt.assert_allclose(
-            spec.spectra[3], self.data.T, err_msg="Complied spectra is wrong.")
+            spec.spectra[3],
+            self.data.loc[:, slice("6.0", "11.0")].T.to_numpy(),
+            err_msg="Complied spectra is wrong."
+        )
 
         # Remove created pickle
         os.remove(f"{data_path}/all_spectra-bin-imf135_300.npy")

--- a/hoki/tests/test_load.py
+++ b/hoki/tests/test_load.py
@@ -173,14 +173,14 @@ class TestLoadAllsSpectra(object):
     # Initialise model_output DataFrame
     # This reduces I/O readings
     data = load.model_output(
-        f"{data_path}/spectra-bin-imf135_300.z002.dat").loc[:, slice("6.0", "11.0")]
+        f"{data_path}/spectra-bin-imf135_300.z002.dat")
 
     # Patch the model_output function
-    @patch("hoki.data_compilers.pd.read_csv")
+    @patch("hoki.data_compilers.np.loadtxt")
     def test_compile_spectra(self, mock_model_output):
 
         # Set the model_output to the DataFrame
-        mock_model_output.return_value = self.data
+        mock_model_output.return_value = self.data.to_numpy()
 
         spec = load.all_spectra(f"{data_path}", "imf135_300")
 
@@ -189,15 +189,21 @@ class TestLoadAllsSpectra(object):
             "No compiled file is created."
 
         # Check output numpy array
-        npt.assert_allclose(spec[3], self.data.T,
-                            err_msg="Loading of files has failed.")
+        npt.assert_allclose(
+            spec[3],
+            self.data.loc[:, slice("6.0", "11.0")].T.to_numpy(),
+            err_msg="Loading of files has failed."
+        )
 
     def test_load_pickled_file(self):
 
         spec = load.all_spectra(f"{data_path}", "imf135_300")
 
         # Check output numpy array
-        npt.assert_allclose(spec[3], self.data.T,
-                            err_msg="Loading of compiled file has failed.")
+        npt.assert_allclose(
+            spec[3],
+            self.data.loc[:, slice("6.0", "11.0")].T.to_numpy(),
+            err_msg="Loading of compiled file has failed."
+        )
 
         os.remove(f"{data_path}/all_spectra-bin-imf135_300.npy")


### PR DESCRIPTION
This is an alternative to #59, either fixes not being able to load for me. This one uses `numpy` exclusively `pandas`.