### PR TITLE
Hot fix for issue #95 

### DIFF
--- a/hoki/cmd.py
+++ b/hoki/cmd.py
@@ -138,6 +138,9 @@ class CMD(HokiObject):
                                            f"If you've just done that and it looks like it didn't work, try to restart " \
                                            f"your notebook or terminal ;). "
 
+        assert MODELS_PATH[-1]=="/" or MODELS_PATH[-1]=='\\', f"DEBUGGING ASSISTANT: Directory MODELS_PATH = {MODELS_PATH}"\
+                                                             f"does not end with '/' or '\\' "
+
         self.path = MODELS_PATH
 
 

--- a/hoki/sedfitting/kvn.py
+++ b/hoki/sedfitting/kvn.py
@@ -289,6 +289,7 @@ class KVN(HokiObject):
 
         self.log_age_cols = log_age_cols
 
+        ### TODO: put this in a function and make bpass_list_spectra a cached property? (Make binray and single priv.att)
         # Making list of relevant spectra files
         if binary and single:
             self.bpass_list_spectra = glob.glob(self.model_path + 'spectra*')
@@ -304,6 +305,7 @@ class KVN(HokiObject):
 
         self.bpass_list_spectra.sort()
 
+        ### TODO: also make this a cached property (z_list will need to be a private attribute we can use in the func)
         # Allow user to select a list of metallicities?
         if z_list is not None:
             self.z_list=z_list


### PR DESCRIPTION
#95 Should not longer be a problem with this fix in `cmd.py`

I made sure to catch both "flavours" of slashes so that the windows people also get the error
```
141         assert MODELS_PATH[-1]=="/" or MODELS_PATH[-1]=='\\', f"DEBUGGING ASSISTANT: Directory MODELS_PATH = {MODELS_PATH}"\ 
142                                                              f"does not end with '/' or '\\' " 
```